### PR TITLE
Make class helpers pure for better tree-shaking

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,5 +1,5 @@
 // A type of promise-like that resolves synchronously and supports only one observer
-export const _Pact = (function() {
+export const _Pact = /*#__PURE__*/(function() {
 	function _Pact() {}
 	_Pact.prototype.then = function(onFulfilled, onRejected) {
 		const result = new _Pact();
@@ -625,7 +625,7 @@ export function _catchInGenerator(body, recover) {
 }
 
 // Asynchronous generator class; accepts the entrypoint of the generator, to which it passes itself when the generator should start
-export const _AsyncGenerator = (function() {
+export const _AsyncGenerator = /*#__PURE__*/(function() {
 	function _AsyncGenerator(entry) {
 		this._entry = entry;
 		this._pact = null;


### PR DESCRIPTION
Adding `/*#__PURE__*/` makes top-level helper classes removable when it’s considered as unused code by UglifyJS and other minifiers. This improves Webpack’s output by not outputting code unused code.

References:

* https://babeljs.io/blog/2017/09/12/planning-for-7.0#pure-annotation-in-specific-transforms-for-minifiers
* https://github.com/babel/babel/issues/5632
* https://github.com/webpack/webpack/issues/2899

This can also be solved by using special [Babel](https://github.com/morlay/babel-plugin-pure-calls-annotation) [plugins](https://github.com/Andarist/babel-plugin-annotate-pure-calls), but I suppose it’s better to have this handled by the core plugin. 