### PR TITLE
Make helpers.js easier to treeshake

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -632,6 +632,9 @@ export const _AsyncGenerator = (function() {
 		this._resolve = null;
 		this._return = null;
 		this._promise = null;
+		this[Symbol.asyncIterator || (Symbol.asyncIterator = Symbol("Symbol.asyncIterator"))] = function() {
+			return this;
+		};
 	}
 
 	function _wrapReturnedValue(value) {
@@ -641,9 +644,6 @@ export const _AsyncGenerator = (function() {
 		return { value: value, done: false };
 	}
 
-	_AsyncGenerator.prototype[Symbol.asyncIterator || (Symbol.asyncIterator = Symbol("Symbol.asyncIterator"))] = function() {
-		return this;
-	};
 	_AsyncGenerator.prototype._yield = function(value) {
 		// Yield the value to the pending next call
 		this._resolve(value && value.then ? value.then(_wrapYieldedValue) : _wrapYieldedValue(value));


### PR DESCRIPTION
This pull request makes the helpers.js file easier for [Rollup](https://rollupjs.org) to treeshake. Rollup (as well as this plugin) is used by e.g. [microbundle](https://github.com/developit/microbundle) where we noticed that the bundled results sometimes contained things that were not strictly necessary.

The current helper.js master version (potentially) sets `Symbol.asyncIterator` when imported. This in turn seems to cause Rollup to include the whole `_AsyncGenerator` helper always when `_forAwaitOf` is included (presumably because `Symbol.asyncIterator` is referred there), even when it's not necessary.

Rollup REPL can be used to demonstrate this:
 1. Go to [this pre-set REPL page](https://rollupjs.org/repl?version=1.7.0&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMiUyRiUyRiUyMENvbXBpbGVkJTIwZnJvbSUyMHRoZSUyMGZvbGxvd2luZyUyMHdpdGglMjAlNjBleHRlcm5hbEhlbHBlcnMlNjAlMjBzZXQlMjB0byUyMCU2MHRydWUlNjAlM0ElNUNuJTJGJTJGJTVDbiUyRiUyRiUyMCUyMCUyMCUyMGV4cG9ydCUyMGRlZmF1bHQlMjBhc3luYyUyMGZ1bmN0aW9uKCklMjAlN0IlNUNuJTJGJTJGJTVDdCUyMCUyMCUyMCUyMGZvciUyMGF3YWl0JTIwKGNvbnN0JTIwYSUyMG9mJTIwJTVCMSUyQyUyMDIlNUQpJTIwJTdCJTdEJTVDbiUyRiUyRiUyMCUyMCUyMCUyMCU3RCU1Q24lMkYlMkYlNUNuJTJGJTJGJTIwTW9kaWZpZWQlMjB0aGUlMjByZXN1bHQlMjBieSUyMHJlcGxhY2luZyUyMGltcG9ydHMlMjB0byUyMGNvbWUlMjBmcm9tJTIwJTVDJTIyLiUyRmhlbHBlcnMlNUMlMjIlNUNuJTJGJTJGJTIwZm9yJTIwZGVtb25zdHJhdGlvbiUyMHB1cnBvc2VzLiU1Q24lNUNuaW1wb3J0JTIwJTdCJTIwX2FzeW5jJTIwJTdEJTIwZnJvbSUyMCU1QyUyMi4lMkZoZWxwZXJzJTVDJTIyJTNCJTVDbmltcG9ydCUyMCU3QiUyMF9jb250aW51ZUlnbm9yZWQlMjAlN0QlMjBmcm9tJTIwJTVDJTIyLiUyRmhlbHBlcnMlNUMlMjIlM0IlNUNuaW1wb3J0JTIwJTdCJTIwX2ZvckF3YWl0T2YlMjAlN0QlMjBmcm9tJTIwJTVDJTIyLiUyRmhlbHBlcnMlNUMlMjIlM0IlNUNuaW1wb3J0JTIwJTdCJTIwX2VtcHR5JTIwJTdEJTIwZnJvbSUyMCU1QyUyMi4lMkZoZWxwZXJzJTVDJTIyJTNCJTVDbiU1Q25leHBvcnQlMjBkZWZhdWx0JTIwX2FzeW5jKGZ1bmN0aW9uJTIwKCklMjAlN0IlNUNuJTIwJTIwcmV0dXJuJTIwX2NvbnRpbnVlSWdub3JlZChfZm9yQXdhaXRPZiglNUIxJTJDJTIwMiU1RCUyQyUyMF9lbXB0eSkpJTNCJTVDbiU3RCklM0IlMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSU3RCUyQyU3QiUyMm5hbWUlMjIlM0ElMjJoZWxwZXJzLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMiUyRiUyRiUyMEFkZCUyMHRoZSUyMGNvbnRlbnRzJTIwb2YlMjBiYWJlbC1wbHVnaW4tdHJhbnNmb3JtLWFzeW5jLXRvLXByb21pc2VzJTJGaGVscGVyLmpzJTIwaGVyZSUyMiU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlMjJmb3JtYXQlMjIlM0ElMjJlc20lMjIlMkMlMjJuYW1lJTIyJTNBJTIybXlCdW5kbGUlMjIlMkMlMjJhbWQlMjIlM0ElN0IlMjJpZCUyMiUzQSUyMiUyMiU3RCUyQyUyMmdsb2JhbHMlMjIlM0ElN0IlN0QlN0QlMkMlMjJleGFtcGxlJTIyJTNBbnVsbCU3RA==).
 1. Paste in the contents of the helper.js master version, note how `_AsyncGenerator` is included in the Rollup output.
 1. Replace the helper.js contents with the one from this pull request. Note how `_AsyncGenerator` is not included anymore.

(Sorry for the copy-pasting required for this demo, but shareable REPL links that already had the helper.js filled in didn't seem to work - maybe the URL was just too long?)

The main change is to move the `Symbol.asyncIterator || (Symbol.asyncIterator = Symbol("Symbol.asyncIterator"))` part inside the `_AsyncGenerator` constructor. ~~Also, the code can't rely `Symbol.asyncIterator` to be defined immediately after importing it anymore, so I added the same check to `_forAwaitOf`. I tried encapsulating this piece of code into its own helper function, but it got included in compilation outputs so I went with this approach.~~ **Update:** On second thought, `_forAwaitOf` doesn't need to be modified. An async generator needs to be instantiated in some way (via helper.js or otherwise), so presumably `Symbol.asyncIterator` will exist before iteration.