### PR TITLE
Ensure async methods always return a promise

### DIFF
--- a/async-to-promises.ts
+++ b/async-to-promises.ts
@@ -2855,7 +2855,7 @@ export default function({
 
 	// Check if a path is a for-await statement (not supported on all Babel versions)
 	function isForAwaitStatement(path: NodePath<any>): path is NodePath<ForAwaitStatement> {
-		return path.isForAwaitStatement ? path.isForAwaitStatement() : false;
+		return (path.isForAwaitStatement && path.node) ? path.isForAwaitStatement() : false;
 	}
 
 	// Check if a path is an ArgumentPlaceholder statement (not supported on all Babel versions)

--- a/async-to-promises.ts
+++ b/async-to-promises.ts
@@ -2855,7 +2855,7 @@ export default function({
 
 	// Check if a path is a for-await statement (not supported on all Babel versions)
 	function isForAwaitStatement(path: NodePath<any>): path is NodePath<ForAwaitStatement> {
-		return (path.isForAwaitStatement && path.node) ? path.isForAwaitStatement() : false;
+		return path.isForAwaitStatement && path.node ? path.isForAwaitStatement() : false;
 	}
 
 	// Check if a path is an ArgumentPlaceholder statement (not supported on all Babel versions)

--- a/tests/class methods with pseudo-variables/hoisted.js
+++ b/tests/class methods with pseudo-variables/hoisted.js
@@ -1,1 +1,1 @@
-function(){return class{testThis(){const _this=this;return _call(function(){return _this;});}testArguments(){const _arguments=arguments;return _call(function(){return _arguments[0];});}};}
+function(){return class{testThis(){const _this=this;return _await(_this);}testArguments(){const _arguments=arguments;return _call(function(){return _await(_arguments[0]);});}};}

--- a/tests/class methods with pseudo-variables/inlined.js
+++ b/tests/class methods with pseudo-variables/inlined.js
@@ -1,1 +1,1 @@
-function(){return class{testThis(){try{const _this=this;return _this;}catch(e){return Promise.reject(e);}}testArguments(){try{const _arguments=arguments;return _arguments[0];}catch(e){return Promise.reject(e);}}};}
+function(){return class{testThis(){const _this=this;return Promise.resolve(_this);}testArguments(){try{const _arguments=arguments;return Promise.resolve(_arguments[0]);}catch(e){return Promise.reject(e);}}};}

--- a/tests/class methods with pseudo-variables/output.js
+++ b/tests/class methods with pseudo-variables/output.js
@@ -1,1 +1,1 @@
-function(){return class{testThis(){const _this=this;return _call(()=>_this);}testArguments(){const _arguments=arguments;return _call(()=>_arguments[0]);}};}
+function(){return class{testThis(){const _this=this;return _await(_this);}testArguments(){const _arguments=arguments;return _call(()=>_await(_arguments[0]));}};}

--- a/tests/class methods/hoisted.js
+++ b/tests/class methods/hoisted.js
@@ -1,1 +1,1 @@
-function(){return class{foo(baz){return _call(function(){return _call(baz);});}static bar(baz){return _call(function(){return _call(baz);});}};}
+function(){return class{foo(baz){return _call(baz);}bar(baz){return _call(function(){return _await(baz());});}static foo(){return _await();}static bar(baz){return _call(baz);}};}

--- a/tests/class methods/inlined.js
+++ b/tests/class methods/inlined.js
@@ -1,1 +1,1 @@
-function(){return class{foo(baz){try{return Promise.resolve(baz());}catch(e){return Promise.reject(e);}}static bar(baz){try{return Promise.resolve(baz());}catch(e){return Promise.reject(e);}}};}
+function(){return class{foo(baz){try{return Promise.resolve(baz());}catch(e){return Promise.reject(e);}}bar(baz){try{return Promise.resolve(baz());}catch(e){return Promise.reject(e);}}static foo(){return Promise.resolve();}static bar(baz){try{return Promise.resolve(baz());}catch(e){return Promise.reject(e);}}};}

--- a/tests/class methods/input.js
+++ b/tests/class methods/input.js
@@ -3,6 +3,10 @@ function() {
         async foo(baz) {
             return await baz();
         }
+        async bar(baz) {
+            return baz();
+        }
+        static async foo() {}
         static async bar(baz) {
             return await baz();
         }

--- a/tests/class methods/output.js
+++ b/tests/class methods/output.js
@@ -1,1 +1,1 @@
-function(){return class{foo(baz){return _call(()=>_call(baz));}static bar(baz){return _call(()=>_call(baz));}};}
+function(){return class{foo(baz){return _call(baz);}bar(baz){return _call(()=>_await(baz()));}static foo(){return _await();}static bar(baz){return _call(baz);}};}


### PR DESCRIPTION
Fixes #41 

This PR make sure that the return of an async method is always a Promise using `inlineHelpers`.
Also, some test has been fixed to properly check this behaviour.